### PR TITLE
Changing age to only be PXD without time

### DIFF
--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -254,7 +254,7 @@ def run():
                 session_start_date_time = pacific.localize(session_start_date_time)
             subject_age = session_start_date_time - subject_dob
 
-            age = "P" + str(subject_age) + "D"
+            age = "P" + str(subject_age.days) + "D"
             if isinstance(subject_metadata["species"], dict):
                 species = subject_metadata["species"]["name"]
             else:


### PR DESCRIPTION
Currently the age of the mouse has extra info in it, like P113 days, 15:00:33.997646D, it should just be P113D in the above example or it will fail dandi validation. 